### PR TITLE
Update plantsaver block to use adafruit-circuitpython-dht

### DIFF
--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -12,7 +12,7 @@ RUN pip3 install --upgrade \
   automationhat \
   paho-mqtt
 
-RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0
+RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 --install-option="--force-pi2"
 
 COPY . /usr/src
 

--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.7.3-buster-build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.7.16-buster-build
 
 RUN install_packages python3-smbus wget unzip libgpiod2
 

--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -12,7 +12,7 @@ RUN pip3 install --upgrade \
   automationhat \
   paho-mqtt
 
-RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 --install-option="--force-pi2"
+RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0
 
 COPY . /usr/src
 

--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -12,7 +12,7 @@ RUN pip3 install --upgrade \
   automationhat \
   paho-mqtt
 
-RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 --install-option="--force-pi2"
+RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 config-settings="--build-option=--force-pi2" 
 
 COPY . /usr/src
 

--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -12,7 +12,7 @@ RUN pip3 install --upgrade \
   automationhat \
   paho-mqtt
 
-RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 config-settings="--build-option=--force-pi2" 
+RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 --config-settings="--build-option=--force-pi2" 
 
 COPY . /usr/src
 

--- a/plantsaver/Dockerfile.template
+++ b/plantsaver/Dockerfile.template
@@ -1,18 +1,15 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.7-buster-build
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.7.3-buster-build
 
-RUN install_packages python3-smbus wget unzip
+RUN install_packages python3-smbus wget unzip libgpiod2
 
 RUN pip3 install --upgrade \
   pip \
-  setuptools \
-  wheel\
   smbus2 \
   RPi.GPIO \
   balena-sdk \ 
   automationhat \
+  adafruit-circuitpython-dht \
   paho-mqtt
-
-RUN python3 -m pip install --no-cache-dir --trusted-host pypi.python.org Adafruit_DHT==1.4.0 --config-settings="--build-option=--force-pi2" 
 
 COPY . /usr/src
 

--- a/plantsaver/plantinha.py
+++ b/plantsaver/plantinha.py
@@ -1,7 +1,8 @@
 import time
 import os
 import automationhat
-import Adafruit_DHT
+import adafruit_dht
+import board
 from balena import Balena
 import json
 import paho.mqtt.client as mqtt
@@ -13,8 +14,7 @@ class PlantSaver:
         self.client                 = mqtt.Client("1")
 
         # Variables
-        self.dht_sensor             = Adafruit_DHT.DHT22
-        self.dht_pin                = int(self.set_variable("dht_pin", 11))
+        self.dht_sensor             = adafruit_dht.DHT22(board.D11)
         self.max_value              = float(self.set_variable("max_value", 2.77)) 
         self.min_value              = float(self.set_variable("min_value", 1.46)) 
         self.target_soil_moisture   = int(self.set_variable("target_soil_moisture", 60))
@@ -45,7 +45,8 @@ class PlantSaver:
         self.moisture_level= 100-(automationhat.analog.one.read()-self.min_value)/((self.max_value-self.min_value)/100)
 
     def read_temperature_humidity(self):
-        self.humidity, self.temperature = Adafruit_DHT.read_retry(self.dht_sensor, self.dht_pin)
+        self.humidity = self.dht_sensor.humidity
+        self.temperature = self.dht_sensor.temperature 
     
     def update_sensors(self):
         self.read_moisture()


### PR DESCRIPTION
This should resolve #20 

I don't have an automation hat to test, but the block appears to only report errors related to no sensor readings now. (I have a Grow HAT, hope to have that working with it's own block soon)
Can someone with an automation hat test and verify?